### PR TITLE
Change `grass_path` to `dirt_path`

### DIFF
--- a/data/speedv3/tags/blocks/speed_blocks.json
+++ b/data/speedv3/tags/blocks/speed_blocks.json
@@ -2,6 +2,6 @@
 	"values": [
 		"minecraft:smooth_stone",
 		"minecraft:smooth_sandstone",
-		"minecraft:grass_path"
+		"minecraft:dirt_path"
 	]
 }


### PR DESCRIPTION
1.17 renamed the ID to be in-line with Bedrock Edition, so this is necessary for the datapack to work on 1.17